### PR TITLE
Check prerequisites before applying firewall rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Role Name
 =========
 
-Uses firewalld on CentOS/Redhat 7 or fedore 21/22 to configure the firewall
+Uses firewalld on CentOS/Redhat 7 or Fedora 21/22 to configure the firewall
 
 Requirements
 ------------

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,10 @@
 ---
+- name: Install firewalld package
+  yum: pkg=firewalld state=present
+
+- name: Ensure firewalld is running and enabled on boot
+  service: name=firewalld state=started enabled=yes
+
 - name: Add firewalld rules for services from vars
   firewalld:
     service={{ item.service }}


### PR DESCRIPTION
Check prerequisites before applying firewall rules:
- firewalld package should be installed,
- firewalld service should be running and enabled on boot.