### PR TITLE
Replace service with command in handler

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,6 +1,4 @@
 ---
-- name: firewalld reload
-  service:
-    name: "firewalld"
-    state: "reloaded"
-
+# 'service reload' was not always working, needs complete reload
+- name: firewalld complete reload
+  command: firewall-cmd --complete-reload


### PR DESCRIPTION
 to carry out 'firewalld --complete-reload' due to new rules not applying via 'reload'