### PR TITLE
Fix mismatch in handler name

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,7 +12,7 @@
     permanent={{ item.permanent | default (True) }}
     state={{ item.state | default ("enabled") }}
   with_items: "{{ firewalld_allow_services }}"
-  notify: firewalld reload
+  notify: firewalld complete reload
 - name: Add firewalld rules for ports from vars
   firewalld:
     port={{ item.port }}
@@ -20,4 +20,4 @@
     permanent={{ item.permanent | default (True) }}
     state={{ item.state | default ("enabled") }}
   with_items: "{{ firewalld_allow_ports }}"
-  notify: firewalld reload
+  notify: firewalld complete reload


### PR DESCRIPTION
Noticed that notify still wasn't working, then realised that we changed the handler name but didn't update the tasks notify option to match.  This commit fixes that.