### PR TITLE
fix-intchange-sourcechange

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,21 @@ The ansible module firewalld is used for the configuration.
 Role Variables
 --------------
 
-There are three hashes:
+There are four hashes:
+ - firewalld_zone
  - firewalld_allow_sources
  - firewalld_allow_services
  - firewalld_allow_ports
+
+Values for firewalld_zones:
+
+    firewalld_zones:
+      zone: [zone]
+      permanent: [True|False] (default: True)
+      state: [present|absent] (default: present)
+      interface: [interface]
+
+interface parameter is used in the handler.
 
 Values for firewalld_allow_sources:
 

--- a/README.md
+++ b/README.md
@@ -11,9 +11,20 @@ The ansible module firewalld is used for the configuration.
 Role Variables
 --------------
 
-There are two hashes:
+There are three hashes:
+ - firewalld_allow_sources
  - firewalld_allow_services
  - firewalld_allow_ports
+
+Values for firewalld_allow_sources:
+
+    firewalld_allow_services:
+      source: <service name>
+      zone: [zone]			(default: public)
+      permanent: [True|False]	(default: True)
+      state: [enabled|disabled]	(default: enabled)
+
+Only source is required!
 
 Values for firewalld_allow_services:
 
@@ -33,15 +44,24 @@ Values for firewalld_allow_ports:
       permanent: [True|False]	(default: True)
       state: [enabled|disabled]	(default: enabled)
 
+Only port is required!
 
 Example Playbook
 ----------------
 
     - hosts: servers
       vars:
+        firewalld_allow_sources:
+          - { source: 192.168.2.0/23, zone: "internal", permanent: True, state: "enabled" }
         firewalld_allow_services:
           - { service: "http" }
           - { service: "telnet", zone: "dmz", permanent: True, state: "disabled" }
+        firewalld_allow_ports:
+          - { port: "161/udp", zone: "internal", permanent: True, state: "enabled" }
+          - { port: "162/udp", zone: "internal", permanent: True, state: "enabled" }
+        firewalld_zones:
+          - { zone: "internal", interface: "ens256", state: "present", permanent: true }
+          - { zone: "dmz", interface: "ens224", state: "present", permanent: true }
       roles:
         - marcelnijenhof.firewalld
 
@@ -54,8 +74,6 @@ Disable firewalld service example
           - { firewalld_disable: true }
       roles:
         - marcelnijenhof.firewalld
-
-
 
 License
 -------

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,4 +1,18 @@
 ---
+- name: change interface zone
+  ansible.builtin.command:
+    argv:
+      - /usr/bin/firewall-cmd
+      - "--change-interface={{ item.interface }}"
+      - --permanent
+      - --zone={{ item.zone }}
+  with_items: "{{ firewalld_zones }}"
+
 # 'service reload' was not always working, needs complete reload
 - name: firewalld complete reload
   command: firewall-cmd --complete-reload
+
+- name: firewalld complete restart
+  ansible.builtin.service:
+    name: firewalld
+    state: restarted

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,21 +10,48 @@
   service: name=firewalld state=stopped enabled=no
   when: firewalld_disable == true
 
+- name: Configure firewalld zones from vars
+  firewalld:
+    zone: "{{ item.zone }}"
+    state: "{{ item.state | default (present) }}"
+    permanent: "{{ item.permanent | default (True) }}"
+  loop: "{{ firewalld_zones }}"
+  notify:
+    - "change interface zone" #MonkeyPatch : Fail to permanently change zone for interface via ansible firewalld module
+    - "firewalld complete reload"
+  when: firewalld_disable == false
+
+- meta: flush_handlers
+
+- name: Add firewalld rules for sources from vars
+  firewalld:
+    source: "{{ item.source }}"
+    zone: "{{ item.zone | default (public) }}"
+    permanent: "{{ item.permanent | default (True) }}"
+    state: "{{ item.state | default (enabled) }}"
+    immediate: "{{ item.immediate | default (True) }}"
+  loop: "{{ firewalld_allow_sources }}"
+  notify: firewalld complete restart
+  when: firewalld_disable == false and item.source is defined
+
 - name: Add firewalld rules for services from vars
   firewalld:
-    service={{ item.service }}
-    zone={{ item.zone | default ("public") }}
-    permanent={{ item.permanent | default (True) }}
-    state={{ item.state | default ("enabled") }}
-  with_items: "{{ firewalld_allow_services }}"
-  notify: firewalld complete reload
-  when: firewalld_disable == false
+    service: "{{ item.service }}"
+    zone: "{{ item.zone | default (public) }}"
+    permanent: "{{ item.permanent | default (True) }}"
+    state: "{{ item.state | default (enabled) }}"
+    immediate: "{{ item.immediate | default (True) }}"
+  loop: "{{ firewalld_allow_services }}"
+  notify: firewalld complete restart
+  when: firewalld_disable == false and item.service is defined
+
 - name: Add firewalld rules for ports from vars
   firewalld:
-    port={{ item.port }}
-    zone={{ item.zone | default ("public") }}
-    permanent={{ item.permanent | default (True) }}
-    state={{ item.state | default ("enabled") }}
-  with_items: "{{ firewalld_allow_ports }}"
-  notify: firewalld complete reload
-  when: firewalld_disable == false
+    port: "{{ item.port }}"
+    zone: "{{ item.zone | default (public) }}"
+    permanent: "{{ item.permanent | default (True) }}"
+    state: "{{ item.state | default (enabled) }}"
+    immediate: "{{ item.immediate | default (True) }}"
+  loop: "{{ firewalld_allow_ports }}"
+  notify: firewalld complete restart
+  when: firewalld_disable == false and item.port is defined


### PR DESCRIPTION
tested on RHEL
- zone are created correctly
- interfaces are added to expected zone
- zone are modified to allow services, ports, from a source.
- firewalld_allow_sources, firewalld_allow_services, firewalld_allow_ports are not mandatory.